### PR TITLE
Do not load on slack.com/admin

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -9,6 +9,7 @@
   "content_scripts": [
     {
       "matches": ["https://*.slack.com/*"],
+      "exclude_matches": ["https://*.slack.com/admin/*"],
       "js": ["js/scrape.js"]
     }
   ],


### PR DESCRIPTION
The buttons are not needed on admin pages, and can be distracting/confusing.