### PR TITLE
Make buttons legible in dark mode.

### DIFF
--- a/js/scrape.js
+++ b/js/scrape.js
@@ -36,11 +36,13 @@ let scraper = {
         let button = document.querySelector('#drupal-meeting-parser-add-with-credit-button');
         button.innerHTML = 'Add with credit';
         button.style.backgroundColor = 'yellow';
+        button.style.color = 'black';
       }
       else {
         let button = document.querySelector('#drupal-meeting-parser-add-without-credit-button');
         button.innerHTML = 'Add without credit';
         button.style.backgroundColor = 'yellow';
+        button.style.color = 'black';
       }
       this.threadInProgress = false;
       this.threadCredits = null;
@@ -52,6 +54,7 @@ let scraper = {
       let button = document.querySelector('#drupal-meeting-parser-clipboard-button');
       button.innerHTML = 'Copy ' + (this.threadCount > 1 ? this.threadCount + ' threads' : 'thread') + ' to clipboard';
       button.style.backgroundColor = 'yellow';
+      button.style.color = 'black';
 
       // The main slack window has an ARIA-expanded item of this thread, so add a checkmark there to help identify which one was saved.
       document.querySelector('div.c-virtual_list__item[aria-expanded="true"] .p-rich_text_section').prepend('✅ ');
@@ -175,11 +178,13 @@ let scraper = {
       this.threadCredits = true;
       let button = document.querySelector('#drupal-meeting-parser-add-with-credit-button');
       button.style.backgroundColor = 'gray';
+      button.style.color = 'white';
       button.innerHTML = '[Processing]';
     }
     else {
       let button = document.querySelector('#drupal-meeting-parser-add-without-credit-button');
       button.style.backgroundColor = 'gray';
+      button.style.color = 'white';
       button.innerHTML = '[Processing]';
     }
     sidebar.scrollTop = 0;
@@ -222,7 +227,7 @@ setTimeout(function() {
   let wrapper = document.createElement('div');
   wrapper.setAttribute('id', 'drupal-meeting-parser-wrapper');
   wrapper.setAttribute('style', "position:absolute;width:800px;height:30px;left:10px;top:3px;z-index:1000;text-align:center;" );
-  let style="width:180px;height:30px;margin-left:5px;margin-right:5px;background-color:yellow;cursor:pointer;display:inline-block;border-radius:4px;border: 1px solid black;box-shadow: 1px 1px #ddd;";
+  let style="width:180px;height:30px;margin-left:5px;margin-right:5px;background-color:yellow;color:black;cursor:pointer;display:inline-block;border-radius:4px;border: 1px solid black;box-shadow: 1px 1px #ddd;";
   let clearThread = document.createElement('button');
   clearThread.addEventListener('click', scraper.clear.bind(scraper));
   clearThread.setAttribute('style', style);
@@ -243,7 +248,7 @@ setTimeout(function() {
   addThreadNoCredit.setAttribute('id', 'drupal-meeting-parser-add-without-credit-button');
   let displayThread = document.createElement('button');
   displayThread.addEventListener('click', scraper.display.bind(scraper));
-  displayThread.setAttribute('style', style + 'background-color:gray;');
+  displayThread.setAttribute('style', style + 'background-color:gray; color: white;');
   displayThread.setAttribute('value', 'Copy to clipboard');
   displayThread.setAttribute('id', 'drupal-meeting-parser-clipboard-button');
   displayThread.appendChild(document.createTextNode('Copy to clipboard'));


### PR DESCRIPTION
This extensions buttons are not visible when Chrome is in dark mode. 
![Slack___project-browser___Drupal___1_new_item_and_Twilio_Authy](https://user-images.githubusercontent.com/1605905/153104171-710b6b8b-c8d7-444b-8ccc-ca6d4393c801.png)

This PR explicitly sets the `color` property, so the text is visible in dark mode. 
![Slack___project-browser___Drupal___1_new_item_and_Twilio_Authy-3](https://user-images.githubusercontent.com/1605905/153104270-5e538788-d5a5-4caa-82c4-ed81cdd4be9a.png)

